### PR TITLE
deploy: Docker 이미지 이름을 모두 소문자로 사용하도록 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,10 @@ jobs:
           # compose.yml을 레포에서 서버 배포 디렉토리로 복사
           cp "${GITHUB_WORKSPACE}/compose.yml" ./compose.yml
 
-          # .env 생성 (들여쓰기 절대 금지)
+          # APP_IMAGE를 자동 생성
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}:latest"
+
+          # .env 생성
           cat > .env <<EOF
           APP_PORT=${{ secrets.APP_PORT }}
           SPRING_PROFILES_ACTIVE=${{ secrets.SPRING_PROFILES_ACTIVE }}
@@ -49,8 +52,8 @@ jobs:
   
           SPRING_DATA_REDIS_HOST=${{ secrets.SPRING_DATA_REDIS_HOST }}
           SPRING_DATA_REDIS_PORT=${{ secrets.SPRING_DATA_REDIS_PORT }}
-  
-          APP_IMAGE=${{ secrets.APP_IMAGE }}
+          
+          APP_IMAGE=$IMAGE
           EOF
 
           chmod 600 .env

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set image name (lowercase)
+        shell: bash
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
Github Organization 생성시 이름을 대문자로 설정해(Bllsoneshot) 레포지토리 주소 경로에 대문자가 포함되었습니다.

배포 파이프라인 중 깃허브 주소의 이름으로 이미지를 만드는 과정이 있으며 이 과정에서 이미지 이름에 대문자가 들어갔습니다.

Docker에는 레포지토리 이름에 대문자가 있으면 안되는 규칙이 있어 빌드 단계에서 실패했습니다. 이 문제를 수정했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #5 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
