### PR TITLE
feat: 회원 권한 조회 기능 추가 및 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // Swagger (SpringDoc OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.20'
 }
 
 kotlin {

--- a/src/main/kotlin/goodspace/bllsoneshot/auth/controller/AuthController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/auth/controller/AuthController.kt
@@ -6,6 +6,8 @@ import goodspace.bllsoneshot.auth.service.AuthService
 import goodspace.bllsoneshot.global.cookie.RefreshTokenCookieProvider
 import goodspace.bllsoneshot.global.cookie.setCookie
 import goodspace.bllsoneshot.global.security.TokenProvider
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -16,6 +18,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/auth")
+@Tag(
+    name = "Auth API"
+)
 class AuthController(
     private val authService: AuthService,
     private val tokenProvider: TokenProvider,
@@ -23,6 +28,15 @@ class AuthController(
 ) {
 
     @PostMapping("/login")
+    @Operation(
+        summary = "로그인",
+        description = """
+            아이디와 비밀번호를 기반으로 로그인합니다.
+            멘토 회원인지 멘티 회원인지 정보를 같이 제공합니다.
+            
+            role: ROLE_MENTOR, ROLE_MENTEE
+        """
+    )
     fun login(
         @Valid @RequestBody request: LoginRequest,
         response: HttpServletResponse
@@ -37,7 +51,8 @@ class AuthController(
 
         return ResponseEntity.ok(
             LoginResponse(
-                accessToken = result.accessToken
+                accessToken = result.accessToken,
+                role = result.role
             )
         )
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/auth/dto/LoginResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/auth/dto/LoginResponse.kt
@@ -1,5 +1,8 @@
 package goodspace.bllsoneshot.auth.dto
 
+import goodspace.bllsoneshot.entity.user.UserRole
+
 data class LoginResponse(
-    val accessToken: String
+    val accessToken: String,
+    val role: UserRole
 )

--- a/src/main/kotlin/goodspace/bllsoneshot/auth/dto/LoginResult.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/auth/dto/LoginResult.kt
@@ -1,6 +1,9 @@
 package goodspace.bllsoneshot.auth.dto
 
+import goodspace.bllsoneshot.entity.user.UserRole
+
 data class LoginResult(
     val accessToken: String,
-    val refreshToken: String
+    val refreshToken: String,
+    val role: UserRole
 )

--- a/src/main/kotlin/goodspace/bllsoneshot/auth/service/AuthService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/auth/service/AuthService.kt
@@ -31,7 +31,8 @@ class AuthService(
 
         return LoginResult(
             accessToken = accessToken,
-            refreshToken = refreshToken
+            refreshToken = refreshToken,
+            role = user.role
         )
     }
 

--- a/src/main/kotlin/goodspace/bllsoneshot/global/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/swagger/SwaggerConfig.kt
@@ -1,0 +1,41 @@
+package goodspace.bllsoneshot.global.swagger
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .servers(
+                listOf(
+                    Server().url("https://runners-hi.site").description("배포 서버 URL 1"),
+                    Server().url("https://api.runners-hi.site").description("배포 서버 URL 2"),
+                    Server().url("http://localhost:8080").description("로컬")
+                )
+            )
+            .addSecurityItem(SecurityRequirement().addList("Bearer Authentication"))
+            .components(Components().addSecuritySchemes("Bearer Authentication", createAPIKeyScheme()))
+            .info(
+                Info()
+                    .title("Runner's High API")
+                    .description("러너스하이 서비스의 API 명세서입니다.")
+                    .version("1.0.0")
+            )
+    }
+
+    private fun createAPIKeyScheme(): SecurityScheme {
+        return SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .bearerFormat("JWT")
+            .scheme("bearer")
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
로그인 응답에 해당 회원의 권한 정보(멘토, 멘티)를 추가했습니다.
Swagger를 통해 문서화했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #18 
- #17 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
