### PR TITLE
feat: 할 일 조회 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -48,5 +48,14 @@ class Task(
     val columnLinks: MutableList<ColumnLink> = mutableListOf()
 
     @OneToMany(mappedBy = "task", fetch = FetchType.LAZY)
+    val proofShots: MutableList<ProofShot> = mutableListOf()
+
+    @OneToMany(mappedBy = "task", fetch = FetchType.LAZY)
     val comments: MutableList<Comment> = mutableListOf()
+
+    fun hasWorkSheet(): Boolean =
+        worksheets.isNotEmpty()
+
+    fun hasProofShot(): Boolean =
+        proofShots.isNotEmpty()
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
@@ -1,0 +1,19 @@
+package goodspace.bllsoneshot.repository.task
+
+import goodspace.bllsoneshot.entity.assignment.Task
+import java.time.LocalDate
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface TaskRepository : JpaRepository<Task, Long> {
+
+    @Query(
+        """
+        SELECT t FROM Task t
+        WHERE t.mentee.id = :userId
+        AND (t.startDate IS NULL OR :date >= t.startDate)
+        AND (t.dueDate IS NULL OR :date <= t.dueDate)
+        """
+    )
+    fun findByMenteeIdAndDate(userId: Long, date: LocalDate): List<Task>
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -1,0 +1,51 @@
+package goodspace.bllsoneshot.task.controller
+
+import goodspace.bllsoneshot.global.security.userId
+import goodspace.bllsoneshot.task.dto.response.TaskResponse
+import goodspace.bllsoneshot.task.service.MenteeTaskService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.security.Principal
+import java.time.LocalDate
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/tasks")
+@Tag(
+    name = "할 일 API (멘티)"
+)
+class TaskController(
+    private val menteeTaskService: MenteeTaskService
+) {
+
+    @GetMapping
+    @Operation(
+        summary = "할 일 목록 조회(날짜 기준)",
+        description = """
+            해당 날짜의 할 일 목록을 조회합니다.
+            
+            date: 조회할 날짜(yyyy-mm-dd)
+            
+            createdBy: 할 일을 만든 사람(ROLE_MENTOR 혹은 ROLE_MENTEE)
+            subject: 과목(KOREAN, ENGLISH, MATH)
+            generalComment: 피드백(총평) 내용
+        """
+    )
+    fun getDailyTasks(
+        principal: Principal,
+        @RequestParam
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        date: LocalDate
+    ): ResponseEntity<List<TaskResponse>> {
+        val userId = principal.userId
+
+        val response = menteeTaskService.findTasksByDate(userId, date)
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskResponse.kt
@@ -1,0 +1,20 @@
+package goodspace.bllsoneshot.task.dto.response
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.entity.user.UserRole
+
+data class TaskResponse(
+    val taskId: Long,
+    val taskName: String,
+
+    val createdBy: UserRole,
+    val subject: Subject,
+    val generalComment: String?,
+
+    val goalMinutes: Int,
+    val actualMinutes: Int?,
+
+    val completed: Boolean,
+    val hasWorksheet: Boolean,
+    val hasProofShot: Boolean
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskMapper.kt
@@ -1,0 +1,30 @@
+package goodspace.bllsoneshot.task.mapper
+
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.task.dto.response.TaskResponse
+import org.springframework.stereotype.Component
+
+@Component
+class TaskMapper {
+
+    fun map(task: Task): TaskResponse {
+        return TaskResponse(
+            taskId = task.id!!,
+            taskName = task.name,
+
+            createdBy = task.createdBy,
+            subject = task.subject,
+            generalComment = task.generalComment?.content,
+
+            goalMinutes = task.goalMinutes,
+            actualMinutes = task.actualMinutes,
+
+            completed = task.completed,
+            hasWorksheet = task.hasWorkSheet(),
+            hasProofShot = task.hasProofShot()
+        )
+    }
+
+    fun map(tasks: List<Task>): List<TaskResponse> =
+        tasks.map { map(it) }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/MenteeTaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/MenteeTaskService.kt
@@ -1,0 +1,23 @@
+package goodspace.bllsoneshot.task.service
+
+import goodspace.bllsoneshot.repository.task.TaskRepository
+import goodspace.bllsoneshot.task.dto.response.TaskResponse
+import goodspace.bllsoneshot.task.mapper.TaskMapper
+import java.time.LocalDate
+import org.springframework.stereotype.Service
+
+@Service
+class MenteeTaskService(
+    private val taskRepository: TaskRepository,
+    private val taskMapper: TaskMapper
+) {
+
+    fun findTasksByDate(
+        userId: Long,
+        date: LocalDate
+    ): List<TaskResponse> {
+        val tasks = taskRepository.findByMenteeIdAndDate(userId, date)
+
+        return taskMapper.map(tasks)
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
날짜를 통해 해당 회원의 할 일을 조회하는 API를 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #25 
