### PR TITLE
feat: 할 일 추가(멘티) API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -20,9 +20,6 @@ class Task(
     @JoinColumn(nullable = false)
     val mentee: User,
 
-    @OneToOne(fetch = FetchType.LAZY)
-    val generalComment: GeneralComment? = null,
-
     @Column(nullable = false)
     val name: String,
     // TODO: 마감일, 생성일이 동시에 null일 수 없도록 검증
@@ -31,8 +28,6 @@ class Task(
     @Column(nullable = false)
     val goalMinutes: Int,
     val actualMinutes: Int?,
-    @Column(nullable = false)
-    val completed: Boolean,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -52,6 +47,12 @@ class Task(
 
     @OneToMany(mappedBy = "task", fetch = FetchType.LAZY)
     val comments: MutableList<Comment> = mutableListOf()
+
+    @OneToOne(fetch = FetchType.LAZY)
+    val generalComment: GeneralComment? = null
+
+    @Column(nullable = false)
+    val completed: Boolean = false
 
     fun hasWorkSheet(): Boolean =
         worksheets.isNotEmpty()

--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -3,5 +3,6 @@ package goodspace.bllsoneshot.global.exception
 enum class ExceptionMessage(
     val message: String
 ) {
-    LOGIN_FAILED("아이디 혹은 비밀번호를 확인해 주세요.")
+    LOGIN_FAILED("아이디 혹은 비밀번호를 확인해 주세요."),
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다.")
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -1,6 +1,8 @@
 package goodspace.bllsoneshot.task.controller
 
 import goodspace.bllsoneshot.global.security.userId
+import goodspace.bllsoneshot.task.dto.request.MenteeTaskCreateRequest
+import jakarta.validation.Valid
 import goodspace.bllsoneshot.task.dto.response.TaskResponse
 import goodspace.bllsoneshot.task.service.MenteeTaskService
 import io.swagger.v3.oas.annotations.Operation
@@ -10,6 +12,8 @@ import java.time.LocalDate
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -17,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/tasks")
 @Tag(
-    name = "할 일 API (멘티)"
+    name = "할 일 API"
 )
 class TaskController(
     private val menteeTaskService: MenteeTaskService
@@ -29,7 +33,7 @@ class TaskController(
         description = """
             해당 날짜의 할 일 목록을 조회합니다.
             
-            date: 조회할 날짜(yyyy-mm-dd)
+            date: 조회할 날짜(yyyy-MM-dd)
             
             createdBy: 할 일을 만든 사람(ROLE_MENTOR 혹은 ROLE_MENTEE)
             subject: 과목(KOREAN, ENGLISH, MATH)
@@ -45,6 +49,29 @@ class TaskController(
         val userId = principal.userId
 
         val response = menteeTaskService.findTasksByDate(userId, date)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/mentee")
+    @Operation(
+        summary = "할 일 추가(멘티)",
+        description = """
+            멘티 권한으로 할 일을 추가합니다.
+            
+            taskName: 할 일 이름
+            goalMinutes: 목표 시간(분)
+            date: 할 일 날짜(yyyy-MM-dd)
+            subject: 과목(KOREAN, ENGLISH, MATH)
+        """
+    )
+    fun addTask(
+        principal: Principal,
+        @Valid @RequestBody request: MenteeTaskCreateRequest
+    ): ResponseEntity<TaskResponse> {
+        val userId = principal.userId
+
+        val response = menteeTaskService.createTask(userId, request)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/MenteeTaskCreateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/MenteeTaskCreateRequest.kt
@@ -1,0 +1,17 @@
+package goodspace.bllsoneshot.task.dto.request
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+import java.time.LocalDate
+
+data class MenteeTaskCreateRequest(
+    @field:NotBlank(message = "할 일 이름이 비어 있습니다.")
+    val taskName: String,
+
+    @field:Positive(message = "목표 시간은 1분 이상이어야 합니다.")
+    val goalMinutes: Int,
+
+    val date: LocalDate,
+    val subject: Subject
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/MenteeTaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/MenteeTaskService.kt
@@ -1,14 +1,21 @@
 package goodspace.bllsoneshot.task.service
 
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.entity.user.UserRole
+import goodspace.bllsoneshot.global.exception.ExceptionMessage
 import goodspace.bllsoneshot.repository.task.TaskRepository
+import goodspace.bllsoneshot.repository.user.UserRepository
+import goodspace.bllsoneshot.task.dto.request.MenteeTaskCreateRequest
 import goodspace.bllsoneshot.task.dto.response.TaskResponse
 import goodspace.bllsoneshot.task.mapper.TaskMapper
 import java.time.LocalDate
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MenteeTaskService(
     private val taskRepository: TaskRepository,
+    private val userRepository: UserRepository,
     private val taskMapper: TaskMapper
 ) {
 
@@ -19,5 +26,26 @@ class MenteeTaskService(
         val tasks = taskRepository.findByMenteeIdAndDate(userId, date)
 
         return taskMapper.map(tasks)
+    }
+
+    @Transactional
+    fun createTask(userId: Long, request: MenteeTaskCreateRequest): TaskResponse {
+        val mentee = userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException(ExceptionMessage.USER_NOT_FOUND.message) }
+
+        val task = Task(
+            mentee = mentee,
+            name = request.taskName,
+            startDate = request.date,
+            dueDate = request.date,
+            goalMinutes = request.goalMinutes,
+            actualMinutes = null,
+            subject = request.subject,
+            createdBy = UserRole.ROLE_MENTEE
+        )
+
+        val savedTask = taskRepository.save(task)
+
+        return taskMapper.map(savedTask)
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
할 일 추가(멘티) API를 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #27 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
