### PR TITLE
feat: 할 일 조회시, 피드백 확인 여부를 같이 응답하도록 개선

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -71,6 +71,15 @@ class Task(
     fun hasFeedback(): Boolean =
         comments.any { it.isFeedback && it.isRegistered }
 
+    fun hasReadAllFeedbacks(): Boolean {
+        if (!hasFeedback()) {
+            return true
+        }
+
+        return comments.filter { it.isFeedback && it.isRegistered }
+            .all { it.isRead }
+    }
+
     fun markFeedbackAsRead() {
         comments.forEach { it.markAsRead() }
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskResponse.kt
@@ -15,6 +15,8 @@ data class TaskResponse(
     val actualMinutes: Int?,
 
     val completed: Boolean,
+    val readFeedback: Boolean,
+    val hasFeedback: Boolean,
     val hasWorksheet: Boolean,
     val hasProofShot: Boolean
 )

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskMapper.kt
@@ -20,6 +20,8 @@ class TaskMapper {
             actualMinutes = task.actualMinutes,
 
             completed = task.completed,
+            readFeedback = task.hasReadAllFeedbacks(),
+            hasFeedback = task.hasFeedback(),
             hasWorksheet = task.hasWorkSheet(),
             hasProofShot = task.hasProofShot()
         )


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
할 일을 조회할 때, 피드백을 확인했는지 여부를 같이 응답하도록 개선했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #34 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
