### PR TITLE
feat: 토큰 재발급 구현 및 로그인 개선

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/auth/service/AuthService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/auth/service/AuthService.kt
@@ -7,6 +7,7 @@ import goodspace.bllsoneshot.global.exception.ExceptionMessage
 import goodspace.bllsoneshot.global.security.TokenProvider
 import goodspace.bllsoneshot.global.security.TokenType
 import goodspace.bllsoneshot.repository.user.UserRepository
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -20,23 +21,40 @@ class AuthService(
 
     @Transactional
     fun login(request: LoginRequest): LoginResult {
-        val user = findUserBy(request.loginId)
+        val user = findUserByLoginId(request.loginId)
         validatePassword(request.password, user.password)
 
         val userId = user.id!!
         val accessToken = tokenProvider.createToken(userId, TokenType.ACCESS, user.role)
-        val refreshToken = tokenProvider.createToken(userId, TokenType.REFRESH, user.role)
-
-        user.refreshToken = refreshToken
+        val newRefreshToken = rotateRefreshToken(user)
 
         return LoginResult(
             accessToken = accessToken,
-            refreshToken = refreshToken,
+            refreshToken = newRefreshToken,
             role = user.role
         )
     }
 
-    private fun findUserBy(loginId: String): User {
+    @Transactional
+    fun reissueAccessToken(refreshToken: String?): LoginResult {
+        validateToken(refreshToken)
+
+        val user = findUserByToken(refreshToken!!)
+        if (user.refreshToken != refreshToken) {
+            throw BadCredentialsException(ExceptionMessage.INVALID_REFRESH_TOKEN.message)
+        }
+
+        val accessToken = tokenProvider.createToken(user.id!!, TokenType.ACCESS, user.role)
+        val newRefreshToken = rotateRefreshToken(user)
+
+        return LoginResult(
+            accessToken = accessToken,
+            refreshToken = newRefreshToken,
+            role = user.role
+        )
+    }
+
+    private fun findUserByLoginId(loginId: String): User {
         return userRepository.findByLoginId(loginId)
             ?: throw IllegalArgumentException(ExceptionMessage.LOGIN_FAILED.message)
     }
@@ -48,5 +66,28 @@ class AuthService(
         if (!passwordEncoder.matches(requestPassword, actualPassword)) {
             throw IllegalArgumentException(ExceptionMessage.LOGIN_FAILED.message)
         }
+    }
+
+    private fun validateToken(refreshToken: String?) {
+        if (refreshToken.isNullOrBlank()) {
+            throw BadCredentialsException(ExceptionMessage.INVALID_REFRESH_TOKEN.message)
+        }
+        if (!tokenProvider.validateToken(refreshToken, TokenType.REFRESH)) {
+            throw BadCredentialsException(ExceptionMessage.INVALID_REFRESH_TOKEN.message)
+        }
+    }
+
+    private fun findUserByToken(refreshToken: String): User {
+        val userId = tokenProvider.getIdFromToken(refreshToken)
+
+        return userRepository.findById(userId)
+            .orElseThrow { BadCredentialsException(ExceptionMessage.INVALID_REFRESH_TOKEN.message) }
+    }
+
+    private fun rotateRefreshToken(user: User): String {
+        val refreshToken = tokenProvider.createToken(user.id!!, TokenType.REFRESH, user.role)
+        user.refreshToken = refreshToken
+
+        return refreshToken
     }
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/global/cookie/CookieUtils.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/cookie/CookieUtils.kt
@@ -1,8 +1,0 @@
-package goodspace.bllsoneshot.global.cookie
-
-import goodspace.bllsoneshot.auth.controller.AuthController.Companion.SET_COOKIE
-import jakarta.servlet.http.HttpServletResponse
-
-fun HttpServletResponse.setCookie(value: String) {
-    addHeader(SET_COOKIE, value)
-}

--- a/src/main/kotlin/goodspace/bllsoneshot/global/cookie/RefreshTokenCookieProvider.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/cookie/RefreshTokenCookieProvider.kt
@@ -1,5 +1,7 @@
 package goodspace.bllsoneshot.global.cookie
 
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseCookie
 import org.springframework.stereotype.Component
@@ -16,13 +18,32 @@ class RefreshTokenCookieProvider(
     private val sameSite: String
 ) {
 
-    fun create(refreshToken: String, maxAgeSeconds: Long): ResponseCookie {
-        return ResponseCookie.from(name, refreshToken)
+    fun addToCookie(
+        refreshToken: String,
+        maxAgeSeconds: Long,
+        response: HttpServletResponse
+    ) {
+        val cookie = ResponseCookie.from(name, refreshToken)
             .httpOnly(true)
             .secure(secure)
             .path(path)
             .sameSite(sameSite)
             .maxAge(maxAgeSeconds)
             .build()
+
+        response.addHeader(SET_COOKIE, cookie.toString())
+    }
+
+    fun extract(request: HttpServletRequest): String? {
+        val cookies = request.cookies ?: return null
+
+        return cookies
+            .firstOrNull { it.name == name }
+            ?.takeIf { it.value.isNotBlank() }
+            ?.value
+    }
+
+    companion object {
+        const val SET_COOKIE = "Set-Cookie"
     }
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionHandler.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -18,6 +19,15 @@ class ExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
+            .body(exception.message)
+    }
+
+    @ExceptionHandler(BadCredentialsException::class)
+    fun handleBadCredentials(exception: BadCredentialsException): ResponseEntity<String> {
+        log.info(exception.stackTraceToString())
+
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
             .body(exception.message)
     }
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -4,12 +4,12 @@ enum class ExceptionMessage(
     val message: String
 ) {
     LOGIN_FAILED("아이디 혹은 비밀번호를 확인해 주세요."),
+    INVALID_REFRESH_TOKEN("유효하지 않거나 만료된 리프레시 토큰입니다."),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     TASK_NOT_FOUND("할 일을 찾을 수 없습니다."),
     FEEDBACK_NOT_FOUND("피드백이 존재하지 않습니다."),
     TASK_ACCESS_DENIED("해당 할 일에 대한 권한이 없습니다."),
     FILE_NOT_FOUND("파일을 찾을 수 없습니다."),
-    ANNOTATION_COUNT_MISMATCH("코멘트와 어노테이션 개수가 일치해야 합니다."),
     CANNOT_COMPLETE_WITHOUT_ACTUAL_MINUTES("시간을 기록하지 않은 할 일은 완료할 수 없습니다."),
     TASK_NOT_SUBMITTABLE("제출할 수 없는 할 일입니다.")
 }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
토큰 재발급 API를 구현했습니다.
로그인 API가 리프레시 토큰을 재발급하도록 개선했습니다.
토큰 관련 유틸 클래스를 개선했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #46

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
