### PR TITLE
feat: 할 일 제출 정보 조회 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -8,6 +8,7 @@ import goodspace.bllsoneshot.task.dto.request.TaskCompleteUpdateRequest
 import goodspace.bllsoneshot.task.dto.request.TaskSubmitRequest
 import goodspace.bllsoneshot.task.dto.response.feedback.TaskFeedbackResponse
 import jakarta.validation.Valid
+import goodspace.bllsoneshot.task.dto.response.TaskSubmitResponse
 import goodspace.bllsoneshot.task.dto.response.TaskResponse
 import goodspace.bllsoneshot.task.service.TaskService
 import io.swagger.v3.oas.annotations.Operation
@@ -84,6 +85,7 @@ class TaskController(
 
         return ResponseEntity.ok(response)
     }
+
     @PostMapping("/mentee")
     @Operation(
         summary = "할 일 추가(멘티)",
@@ -103,7 +105,34 @@ class TaskController(
         return ResponseEntity.ok(response)
     }
 
-    @PutMapping("/{taskId}")
+    @GetMapping("/{taskId}/submit")
+    @Operation(
+        summary = "할 일 제출 정보 조회",
+        description = """
+            할 일에 대한 제출 정보를 조회합니다.
+            응답의 proofShots 구조를 그대로 수정하여 PUT /tasks/{taskId} 요청 본문으로 사용할 수 있습니다.
+            
+            이미 멘토가 피드백을 남긴 할 일은 조회할 수 없습니다.
+
+            [응답]
+            taskId: 할 일 ID
+            name: 할 일 이름
+            subject: 과목(KOREAN, ENGLISH, MATH)
+            proofShots: 인증 사진 목록
+        """
+    )
+    fun getTaskForSubmit(
+        principal: Principal,
+        @PathVariable taskId: Long
+    ): ResponseEntity<TaskSubmitResponse> {
+        val userId = principal.userId
+
+        val response = taskService.getTaskForSubmit(userId, taskId)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @PutMapping("/{taskId}/submit")
     @Operation(
         summary = "할 일 제출",
         description = """
@@ -128,7 +157,7 @@ class TaskController(
         return NO_CONTENT
     }
 
-    @GetMapping("/{taskId}")
+    @GetMapping("/{taskId}/feedback")
     @Operation(
         summary = "피드백 조회",
         description = """

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/ProofShotSubmitResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/ProofShotSubmitResponse.kt
@@ -1,0 +1,6 @@
+package goodspace.bllsoneshot.task.dto.response
+
+data class ProofShotSubmitResponse(
+    val imageFileId: Long,
+    val questions: List<QuestionSubmitResponse>
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/QuestionSubmitResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/QuestionSubmitResponse.kt
@@ -1,0 +1,8 @@
+package goodspace.bllsoneshot.task.dto.response
+
+data class QuestionSubmitResponse(
+    val number: Int,
+    val content: String,
+    val percentX: Double,
+    val percentY: Double
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskSubmitResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskSubmitResponse.kt
@@ -1,0 +1,10 @@
+package goodspace.bllsoneshot.task.dto.response
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+
+data class TaskSubmitResponse(
+    val taskId: Long,
+    val name: String,
+    val subject: Subject,
+    val proofShots: List<ProofShotSubmitResponse>
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/ProofShotSubmitMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/ProofShotSubmitMapper.kt
@@ -1,0 +1,22 @@
+package goodspace.bllsoneshot.task.mapper
+
+import goodspace.bllsoneshot.entity.assignment.ProofShot
+import goodspace.bllsoneshot.task.dto.response.ProofShotSubmitResponse
+import org.springframework.stereotype.Component
+
+@Component
+class ProofShotSubmitMapper(
+    private val questionSubmitMapper: QuestionSubmitMapper
+) {
+
+    fun map(proofShot: ProofShot): ProofShotSubmitResponse {
+        val questions = proofShot.questComments
+            .sortedBy { it.commentAnnotation.number }
+            .map { questionSubmitMapper.map(it) }
+
+        return ProofShotSubmitResponse(
+            imageFileId = proofShot.file.id!!,
+            questions = questions
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/QuestionSubmitMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/QuestionSubmitMapper.kt
@@ -1,0 +1,20 @@
+package goodspace.bllsoneshot.task.mapper
+
+import goodspace.bllsoneshot.entity.assignment.Comment
+import goodspace.bllsoneshot.task.dto.response.QuestionSubmitResponse
+import org.springframework.stereotype.Component
+
+@Component
+class QuestionSubmitMapper {
+
+    fun map(comment: Comment): QuestionSubmitResponse {
+        val annotation = comment.commentAnnotation
+
+        return QuestionSubmitResponse(
+            number = annotation.number,
+            content = comment.content,
+            percentX = annotation.percentX,
+            percentY = annotation.percentY
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskSubmitMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskSubmitMapper.kt
@@ -1,0 +1,20 @@
+package goodspace.bllsoneshot.task.mapper
+
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.task.dto.response.TaskSubmitResponse
+import org.springframework.stereotype.Component
+
+@Component
+class TaskSubmitMapper(
+    private val proofShotSubmitMapper: ProofShotSubmitMapper
+) {
+
+    fun map(task: Task): TaskSubmitResponse {
+        return TaskSubmitResponse(
+            taskId = task.id!!,
+            name = task.name,
+            subject = task.subject,
+            proofShots = task.proofShots.map { proofShotSubmitMapper.map(it) }
+        )
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
할 일에 대한 제출 정보를 조회하는 API를 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #33 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
