### PR TITLE
feat: 미래의 할 일을 완료할 수 없도록 개선

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -11,6 +11,7 @@ enum class ExceptionMessage(
     TASK_ACCESS_DENIED("해당 할 일에 대한 권한이 없습니다."),
     FILE_NOT_FOUND("파일을 찾을 수 없습니다."),
     CANNOT_COMPLETE_WITHOUT_ACTUAL_MINUTES("시간을 기록하지 않은 할 일은 완료할 수 없습니다."),
+    CANNOT_COMPLETE_FUTURE_TASK("미래의 할 일은 완료할 수 없습니다."),
     TASK_NOT_SUBMITTABLE("제출할 수 없는 할 일입니다."),
     START_OR_END_DATE_REQUIRED("시작일과 마감일 중 하나는 반드시 입력해야 합니다."),
     DATE_INVALID("시작일은 마감일보다 이후일 수 없습니다.")

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -190,8 +190,12 @@ class TaskController(
         summary = "할 일 완료 상태 수정",
         description = """
             할 일의 완료 상태를 변경합니다.
-            시간을 기록하지 않은 할 일은 완료할 수 없습니다.
             
+            시간을 기록하지 않은 할 일은 완료할 수 없습니다.
+            미래의 할 일은 완료할 수 없습니다.
+            
+            [요청]
+            currentDate: 조회할 날짜(yyyy-MM-dd)
             completed: 완료 여부(true/false)
         """
     )

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/TaskCompleteUpdateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/TaskCompleteUpdateRequest.kt
@@ -1,5 +1,8 @@
 package goodspace.bllsoneshot.task.dto.request
 
+import java.time.LocalDate
+
 data class TaskCompleteUpdateRequest(
-    val completed: Boolean
+    val completed: Boolean,
+    val currentDate: LocalDate
 )

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -147,8 +147,19 @@ class TaskService(
         val task = findTaskBy(taskId)
 
         validateTaskOwnership(task, userId)
+        if (request.completed) {
+            validateTaskCompletable(task, request.currentDate)
+        }
 
         task.completed = request.completed
+    }
+
+    private fun validateTaskCompletable(task: Task, currentDate: LocalDate) {
+        val startDate = task.startDate ?: return
+
+        if (startDate.isAfter(currentDate)) {
+            throw IllegalStateException(CANNOT_COMPLETE_FUTURE_TASK.message)
+        }
     }
 
     private fun validateDate(startDate: LocalDate?, dueDate: LocalDate?) {


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
할 일의 `startDate`가 현재 일자보다 미래일 경우, 완료로 수정할 수 없도록 개선했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #53 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
