### PR TITLE
feat: 학습 시간 기록 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -34,7 +34,7 @@ class Task(
 
     @Column(nullable = false)
     val goalMinutes: Int,
-    val actualMinutes: Int?,
+    var actualMinutes: Int?,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -4,6 +4,7 @@ import goodspace.bllsoneshot.global.response.NO_CONTENT
 import goodspace.bllsoneshot.global.security.userId
 import goodspace.bllsoneshot.task.dto.request.MenteeTaskCreateRequest
 import goodspace.bllsoneshot.task.dto.request.MentorTaskCreateRequest
+import goodspace.bllsoneshot.task.dto.request.ActualMinutesUpdateRequest
 import goodspace.bllsoneshot.task.dto.request.TaskCompleteUpdateRequest
 import goodspace.bllsoneshot.task.dto.request.TaskSubmitRequest
 import goodspace.bllsoneshot.task.dto.response.feedback.TaskFeedbackResponse
@@ -185,17 +186,44 @@ class TaskController(
         return ResponseEntity.ok(response)
     }
 
-    @PatchMapping("/{taskId}")
+    @PutMapping("/{taskId}/actual-minutes")
+    @Operation(
+        summary = "시간 기록",
+        description = """
+            해당 할 일에 대한 학습 시간을 기록합니다.
+            
+            본인의 할 일에 대해서만 호출할 수 있습니다.
+            미래의 할 일에 대해선 호출할 수 없습니다.
+            
+            [요청]
+            currentDate: 현재 날짜(yyyy-MM-dd)
+            actualMinutes: 학습 시간(null로 보낼 경우, 학습 시간이 없는 것으로 간주)
+        """
+    )
+    fun updateActualMinutes(
+        principal: Principal,
+        @PathVariable taskId: Long,
+        @RequestBody request: ActualMinutesUpdateRequest
+    ): ResponseEntity<Void> {
+        val userId = principal.userId
+
+        taskService.updateActualMinutes(userId, taskId, request)
+
+        return NO_CONTENT
+    }
+
+    @PatchMapping("/{taskId}/completed")
     @Operation(
         summary = "할 일 완료 상태 수정",
         description = """
             할 일의 완료 상태를 변경합니다.
             
+            본인의 할 일에 대해서만 호출할 수 있습니다.
             시간을 기록하지 않은 할 일은 완료할 수 없습니다.
             미래의 할 일은 완료할 수 없습니다.
             
             [요청]
-            currentDate: 조회할 날짜(yyyy-MM-dd)
+            currentDate: 현재 날짜(yyyy-MM-dd)
             completed: 완료 여부(true/false)
         """
     )

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/ActualMinutesUpdateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/ActualMinutesUpdateRequest.kt
@@ -1,0 +1,8 @@
+package goodspace.bllsoneshot.task.dto.request
+
+import java.time.LocalDate
+
+data class ActualMinutesUpdateRequest(
+    val currentDate: LocalDate,
+    val actualMinutes: Int?
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -154,6 +154,20 @@ class TaskService(
         task.completed = request.completed
     }
 
+    @Transactional
+    fun updateActualMinutes(
+        userId: Long,
+        taskId: Long,
+        request: ActualMinutesUpdateRequest
+    ) {
+        val task = findTaskBy(taskId)
+
+        validateTaskOwnership(task, userId)
+        validateTaskCompletable(task, request.currentDate)
+
+        task.actualMinutes = request.actualMinutes
+    }
+
     private fun validateTaskCompletable(task: Task, currentDate: LocalDate) {
         val startDate = task.startDate ?: return
 


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
`Task`의 `actualMinutes`를 기록하는 API를 구현했습니다.
한 API를 생성/수정에 같이 사용 가능하도록 PUT 방식으로 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #55 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
