### PR TITLE
feat: 학습 완료/시간 기록 API 형태 수정

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -3,12 +3,12 @@ package goodspace.bllsoneshot.entity.assignment
 import goodspace.bllsoneshot.entity.BaseEntity
 import goodspace.bllsoneshot.entity.user.User
 import goodspace.bllsoneshot.entity.user.UserRole
-import goodspace.bllsoneshot.global.exception.ExceptionMessage.CANNOT_COMPLETE_WITHOUT_ACTUAL_MINUTES
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.NEGATIVE_ACTUAL_MINUTES
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.CascadeType
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -34,7 +34,6 @@ class Task(
 
     @Column(nullable = false)
     val goalMinutes: Int,
-    var actualMinutes: Int?,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -58,9 +57,11 @@ class Task(
 
     @Column(nullable = false)
     var completed: Boolean = false
+
+    var actualMinutes: Int? = null
         set(value) {
-            if (value) {
-                check(actualMinutes != null) { CANNOT_COMPLETE_WITHOUT_ACTUAL_MINUTES.message }
+            if (value != null && value < MINIMUM_ACTUAL_MINUTES) {
+                throw IllegalArgumentException(NEGATIVE_ACTUAL_MINUTES.message)
             }
 
             field = value
@@ -86,5 +87,9 @@ class Task(
 
     fun markFeedbackAsRead() {
         comments.forEach { it.markAsRead() }
+    }
+
+    companion object {
+        private const val MINIMUM_ACTUAL_MINUTES = 0
     }
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -10,9 +10,10 @@ enum class ExceptionMessage(
     FEEDBACK_NOT_FOUND("피드백이 존재하지 않습니다."),
     TASK_ACCESS_DENIED("해당 할 일에 대한 권한이 없습니다."),
     FILE_NOT_FOUND("파일을 찾을 수 없습니다."),
-    CANNOT_COMPLETE_WITHOUT_ACTUAL_MINUTES("시간을 기록하지 않은 할 일은 완료할 수 없습니다."),
     CANNOT_COMPLETE_FUTURE_TASK("미래의 할 일은 완료할 수 없습니다."),
+    INCOMPLETED_TASK("완료되지 않은 할 일입니다."),
     TASK_NOT_SUBMITTABLE("제출할 수 없는 할 일입니다."),
     START_OR_END_DATE_REQUIRED("시작일과 마감일 중 하나는 반드시 입력해야 합니다."),
-    DATE_INVALID("시작일은 마감일보다 이후일 수 없습니다.")
+    DATE_INVALID("시작일은 마감일보다 이후일 수 없습니다."),
+    NEGATIVE_ACTUAL_MINUTES("학습 시간은 음수일 수 없습니다.")
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -5,7 +5,7 @@ import goodspace.bllsoneshot.global.security.userId
 import goodspace.bllsoneshot.task.dto.request.MenteeTaskCreateRequest
 import goodspace.bllsoneshot.task.dto.request.MentorTaskCreateRequest
 import goodspace.bllsoneshot.task.dto.request.ActualMinutesUpdateRequest
-import goodspace.bllsoneshot.task.dto.request.TaskCompleteUpdateRequest
+import goodspace.bllsoneshot.task.dto.request.TaskCompleteRequest
 import goodspace.bllsoneshot.task.dto.request.TaskSubmitRequest
 import goodspace.bllsoneshot.task.dto.response.feedback.TaskFeedbackResponse
 import jakarta.validation.Valid
@@ -186,18 +186,43 @@ class TaskController(
         return ResponseEntity.ok(response)
     }
 
-    @PutMapping("/{taskId}/actual-minutes")
+    @PatchMapping("/{taskId}/completed")
     @Operation(
-        summary = "시간 기록",
+        summary = "할 일 완료",
         description = """
-            해당 할 일에 대한 학습 시간을 기록합니다.
+            할 일을 완료합니다.
             
-            본인의 할 일에 대해서만 호출할 수 있습니다.
             미래의 할 일에 대해선 호출할 수 없습니다.
+            본인의 할 일에 대해서만 호출할 수 있습니다.
             
             [요청]
             currentDate: 현재 날짜(yyyy-MM-dd)
-            actualMinutes: 학습 시간(null로 보낼 경우, 학습 시간이 없는 것으로 간주)
+            actualMinutes: 학습 시간(분, 0 이상)
+        """
+    )
+    fun updateCompleted(
+        principal: Principal,
+        @PathVariable taskId: Long,
+        @RequestBody request: TaskCompleteRequest
+    ): ResponseEntity<Void> {
+        val userId = principal.userId
+
+        taskService.updateCompleted(userId, taskId, request)
+
+        return NO_CONTENT
+    }
+
+    @PutMapping("/{taskId}/actual-minutes")
+    @Operation(
+        summary = "학습 시간 수정",
+        description = """
+            할 일의 학습 시간을 수정합니다.
+            
+            완료된 할 일에 대해서만 호출할 수 있습니다.
+            본인의 할 일에 대해서만 호출할 수 있습니다.
+            
+            [요청]
+            actualMinutes: 학습 시간(분, 0 이상)
         """
     )
     fun updateActualMinutes(
@@ -208,33 +233,6 @@ class TaskController(
         val userId = principal.userId
 
         taskService.updateActualMinutes(userId, taskId, request)
-
-        return NO_CONTENT
-    }
-
-    @PatchMapping("/{taskId}/completed")
-    @Operation(
-        summary = "할 일 완료 상태 수정",
-        description = """
-            할 일의 완료 상태를 변경합니다.
-            
-            본인의 할 일에 대해서만 호출할 수 있습니다.
-            시간을 기록하지 않은 할 일은 완료할 수 없습니다.
-            미래의 할 일은 완료할 수 없습니다.
-            
-            [요청]
-            currentDate: 현재 날짜(yyyy-MM-dd)
-            completed: 완료 여부(true/false)
-        """
-    )
-    fun updateCompleted(
-        principal: Principal,
-        @PathVariable taskId: Long,
-        @Valid @RequestBody request: TaskCompleteUpdateRequest
-    ): ResponseEntity<Void> {
-        val userId = principal.userId
-
-        taskService.updateCompleted(userId, taskId, request)
 
         return NO_CONTENT
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/ActualMinutesUpdateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/ActualMinutesUpdateRequest.kt
@@ -1,8 +1,5 @@
 package goodspace.bllsoneshot.task.dto.request
 
-import java.time.LocalDate
-
 data class ActualMinutesUpdateRequest(
-    val currentDate: LocalDate,
-    val actualMinutes: Int?
+    val actualMinutes: Int
 )

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/TaskCompleteRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/TaskCompleteRequest.kt
@@ -1,0 +1,9 @@
+package goodspace.bllsoneshot.task.dto.request
+
+import java.time.LocalDate
+
+data class TaskCompleteRequest(
+    val currentDate: LocalDate,
+
+    val actualMinutes: Int
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/TaskCompleteUpdateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/TaskCompleteUpdateRequest.kt
@@ -1,8 +1,0 @@
-package goodspace.bllsoneshot.task.dto.request
-
-import java.time.LocalDate
-
-data class TaskCompleteUpdateRequest(
-    val completed: Boolean,
-    val currentDate: LocalDate
-)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -52,7 +52,6 @@ class TaskService(
             dueDate = request.dueDate,
             name = request.taskName,
             goalMinutes = request.goalMinutes,
-            actualMinutes = null,
             createdBy = UserRole.ROLE_MENTOR
         )
         task.worksheets.addAll(
@@ -90,7 +89,6 @@ class TaskService(
             startDate = request.date,
             dueDate = request.date,
             goalMinutes = request.goalMinutes,
-            actualMinutes = null,
             subject = request.subject,
             createdBy = UserRole.ROLE_MENTEE
         )
@@ -142,16 +140,15 @@ class TaskService(
     fun updateCompleted(
         userId: Long,
         taskId: Long,
-        request: TaskCompleteUpdateRequest
+        request: TaskCompleteRequest
     ) {
         val task = findTaskBy(taskId)
 
         validateTaskOwnership(task, userId)
-        if (request.completed) {
-            validateTaskCompletable(task, request.currentDate)
-        }
+        validateTaskCompletable(task, request.currentDate)
 
-        task.completed = request.completed
+        task.actualMinutes = request.actualMinutes
+        task.completed = true
     }
 
     @Transactional
@@ -163,7 +160,7 @@ class TaskService(
         val task = findTaskBy(taskId)
 
         validateTaskOwnership(task, userId)
-        validateTaskCompletable(task, request.currentDate)
+        validateTaskCompleted(task)
 
         task.actualMinutes = request.actualMinutes
     }
@@ -241,5 +238,9 @@ class TaskService(
 
     private fun validateTaskSubmittable(task: Task) {
         check(!task.hasFeedback()) { TASK_NOT_SUBMITTABLE.message }
+    }
+
+    private fun validateTaskCompleted(task: Task) {
+        check(task.completed) { INCOMPLETED_TASK.message }
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
할 일에 대한 완료 및 시간 API 형태를 수정했습니다.
- 완료 시점에 시간도 기록하도록 수정했습니다.
- 완료된 할 일을 비완료 상태로 만들 수 없도록 기능을 제한했습니다.
학습 시간에 대한 제약조건을 엔티티 클래스가 책임지도록 개선했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #57 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
