### PR TITLE
feat: 할 일 삭제(멘티) API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -13,6 +13,7 @@ enum class ExceptionMessage(
     CANNOT_COMPLETE_FUTURE_TASK("미래의 할 일은 완료할 수 없습니다."),
     INCOMPLETED_TASK("완료되지 않은 할 일입니다."),
     TASK_NOT_SUBMITTABLE("제출할 수 없는 할 일입니다."),
+    CANNOT_DELETE_MENTOR_CREATED_TASK("멘토가 만든 할 일은 삭제할 수 없습니다."),
     START_OR_END_DATE_REQUIRED("시작일과 마감일 중 하나는 반드시 입력해야 합니다."),
     DATE_INVALID("시작일은 마감일보다 이후일 수 없습니다."),
     NEGATIVE_ACTUAL_MINUTES("학습 시간은 음수일 수 없습니다.")

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -18,6 +18,7 @@ import java.security.Principal
 import java.time.LocalDate
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -233,6 +234,27 @@ class TaskController(
         val userId = principal.userId
 
         taskService.updateActualMinutes(userId, taskId, request)
+
+        return NO_CONTENT
+    }
+
+    @DeleteMapping("/{taskId}/mentee")
+    @Operation(
+        summary = "할 일 삭제(멘티)",
+        description = """
+            할 일을 삭제합니다.
+            
+            멘티가 만든 할 일만 삭제할 수 있습니다.
+            본인의 할 일만 삭제할 수 있습니다.
+        """
+    )
+    fun deleteTaskByMentee(
+        principal: Principal,
+        @PathVariable taskId: Long
+    ): ResponseEntity<Void> {
+        val userId = principal.userId
+
+        taskService.deleteTaskByMentee(userId, taskId)
 
         return NO_CONTENT
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -165,6 +165,16 @@ class TaskService(
         task.actualMinutes = request.actualMinutes
     }
 
+    @Transactional
+    fun deleteTaskByMentee(userId: Long, taskId: Long) {
+        val task = findTaskBy(taskId)
+
+        validateTaskOwnership(task, userId)
+        validateDeletableByMentee(task)
+
+        taskRepository.delete(task)
+    }
+
     private fun validateTaskCompletable(task: Task, currentDate: LocalDate) {
         val startDate = task.startDate ?: return
 
@@ -242,5 +252,9 @@ class TaskService(
 
     private fun validateTaskCompleted(task: Task) {
         check(task.completed) { INCOMPLETED_TASK.message }
+    }
+
+    private fun validateDeletableByMentee(task: Task) {
+        check(task.createdBy == UserRole.ROLE_MENTEE) { CANNOT_DELETE_MENTOR_CREATED_TASK.message }
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
멘티가 본인의 할 일을 삭제할 때 호출할 API를 구현했습니다.
멘토가 만든 할 일이거나, 본인에게 할당된 할 일이 아니라면 예외를 던지도록 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #59 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
