### PR TITLE
feat: 전체 학습 현황 조회 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/controller/MyPageController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/controller/MyPageController.kt
@@ -1,0 +1,51 @@
+package goodspace.bllsoneshot.mypage.controller
+
+import goodspace.bllsoneshot.global.security.userId
+import goodspace.bllsoneshot.mypage.dto.response.LearningStatusResponse
+import goodspace.bllsoneshot.mypage.service.MyPageService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.security.Principal
+import java.time.LocalDate
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/users/me")
+@Tag(
+    name = "마이 페이지 API"
+)
+class MyPageController(
+    private val myPageService: MyPageService
+) {
+
+    @GetMapping("/learning-status")
+    @Operation(
+        summary = "전체 학습 현황 조회",
+        description = """
+            과목별로, '완료된 할 일'의 개수와 '할 일'의 개수를 조회합니다.
+            
+            [요청]
+            date: 조회할 할 일의 날짜(yyyy-MM-dd)
+            
+            [응답]
+            subject: 과목(KOREAN, ENGLISH, MATH)
+            taskAmount: 해당 과목의 할 일 개수
+            completedTaskAmount: 해당 과목의 완료된 할 일 개수
+        """
+    )
+    fun getTotalLearningStatus(
+        principal: Principal,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
+    ): ResponseEntity<List<LearningStatusResponse>> {
+        val userId = principal.userId
+
+        val response = myPageService.getTotalLearningStatus(userId, date)
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/dto/response/LearningStatusResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/dto/response/LearningStatusResponse.kt
@@ -1,0 +1,9 @@
+package goodspace.bllsoneshot.mypage.dto.response
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+
+data class LearningStatusResponse(
+    val subject: Subject,
+    val taskAmount: Int,
+    val completedTaskAmount: Int
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/mapper/LearningStatusMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/mapper/LearningStatusMapper.kt
@@ -1,0 +1,23 @@
+package goodspace.bllsoneshot.mypage.mapper
+
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.mypage.dto.response.LearningStatusResponse
+import org.springframework.stereotype.Component
+
+@Component
+class LearningStatusMapper {
+
+    fun map(
+        subject: Subject,
+        tasks: List<Task>
+    ): LearningStatusResponse {
+        val subjectTasks = tasks.filter { it.subject == subject }
+
+        return LearningStatusResponse(
+            subject = subject,
+            taskAmount = subjectTasks.size,
+            completedTaskAmount = subjectTasks.count { it.completed }
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/service/MyPageService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/service/MyPageService.kt
@@ -1,0 +1,24 @@
+package goodspace.bllsoneshot.mypage.service
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.mypage.dto.response.LearningStatusResponse
+import goodspace.bllsoneshot.mypage.mapper.LearningStatusMapper
+import goodspace.bllsoneshot.repository.task.TaskRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class MyPageService(
+    private val taskRepository: TaskRepository,
+    private val learningStatusMapper: LearningStatusMapper
+) {
+
+    @Transactional(readOnly = true)
+    fun getTotalLearningStatus(userId: Long, date: LocalDate): List<LearningStatusResponse> {
+        val tasks = taskRepository.findByMenteeIdAndDate(userId, date)
+
+        return Subject.entries
+            .map { learningStatusMapper.map(it, tasks) }
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
마이페이지에서 본인의 전체 학습 현황을 조회할 수 있도록 API를 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #61 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
