### PR TITLE
feat: 과목별 학습 현황 조회 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/controller/MyPageController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/controller/MyPageController.kt
@@ -1,6 +1,8 @@
 package goodspace.bllsoneshot.mypage.controller
 
+import goodspace.bllsoneshot.entity.assignment.Subject
 import goodspace.bllsoneshot.global.security.userId
+import goodspace.bllsoneshot.mypage.dto.response.LearningHistoryResponse
 import goodspace.bllsoneshot.mypage.dto.response.LearningStatusResponse
 import goodspace.bllsoneshot.mypage.service.MyPageService
 import io.swagger.v3.oas.annotations.Operation
@@ -10,6 +12,7 @@ import java.time.LocalDate
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -45,6 +48,39 @@ class MyPageController(
         val userId = principal.userId
 
         val response = myPageService.getTotalLearningStatus(userId, date)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/learning-status/{subject}")
+    @Operation(
+        summary = "학습 현황 조회(단일 과목)",
+        description = """
+            해당 과목의 학습 현황(히스토리)을 조회합니다.
+            
+            [정렬]
+            1. 완료되지 않은 일이며, 더 최근에 만들어진 할 일
+            2. 완료되지 않은 일이며, 더 과거에 만들어진 할 일
+            3. 완료된 일이며, 더 최근에 만들어진 할 일
+            4. 완료된 일이며, 더 과거에 만들어진 할 일
+            
+            [요청]
+            date: 조회할 할 일의 날짜(yyyy-MM-dd)
+            subject: 과목(KOREAN, ENGLISH, MATH)
+            
+            [응답]
+            todayTasks: 오늘(date)의 할 일 목록(마감일이 있고, 학습 시작일 ~ 마감일에 date가 포함되는 할 일)
+            historyTasks: 지난 할 일 목록(학습 마감일이 date 이전인 할 일, 학습 마감일이 없는 할 일)
+        """
+    )
+    fun getLearningStatusBySubject(
+        principal: Principal,
+        @PathVariable subject: Subject,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
+    ): ResponseEntity<LearningHistoryResponse> {
+        val userId = principal.userId
+
+        val response = myPageService.getLearningStatusBySubject(userId, subject, date)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/dto/response/LearningHistoryResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/dto/response/LearningHistoryResponse.kt
@@ -1,0 +1,8 @@
+package goodspace.bllsoneshot.mypage.dto.response
+
+import goodspace.bllsoneshot.task.dto.response.TaskResponse
+
+data class LearningHistoryResponse(
+    val todayTasks: List<TaskResponse>,
+    val historyTasks: List<TaskResponse>
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/mapper/LearningHistoryMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/mapper/LearningHistoryMapper.kt
@@ -1,0 +1,22 @@
+package goodspace.bllsoneshot.mypage.mapper
+
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.mypage.dto.response.LearningHistoryResponse
+import goodspace.bllsoneshot.task.mapper.TaskMapper
+import org.springframework.stereotype.Component
+
+@Component
+class LearningHistoryMapper(
+    private val taskMapper: TaskMapper
+) {
+
+    fun map(
+        todayTasks: List<Task>,
+        historyTasks: List<Task>
+    ): LearningHistoryResponse {
+        return LearningHistoryResponse(
+            todayTasks = taskMapper.map(todayTasks),
+            historyTasks = taskMapper.map(historyTasks)
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/mypage/service/MyPageService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mypage/service/MyPageService.kt
@@ -1,7 +1,10 @@
 package goodspace.bllsoneshot.mypage.service
 
+import goodspace.bllsoneshot.entity.assignment.Task
 import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.mypage.dto.response.LearningHistoryResponse
 import goodspace.bllsoneshot.mypage.dto.response.LearningStatusResponse
+import goodspace.bllsoneshot.mypage.mapper.LearningHistoryMapper
 import goodspace.bllsoneshot.mypage.mapper.LearningStatusMapper
 import goodspace.bllsoneshot.repository.task.TaskRepository
 import org.springframework.stereotype.Service
@@ -11,14 +14,27 @@ import java.time.LocalDate
 @Service
 class MyPageService(
     private val taskRepository: TaskRepository,
-    private val learningStatusMapper: LearningStatusMapper
+    private val learningStatusMapper: LearningStatusMapper,
+    private val learningHistoryMapper: LearningHistoryMapper
 ) {
 
     @Transactional(readOnly = true)
     fun getTotalLearningStatus(userId: Long, date: LocalDate): List<LearningStatusResponse> {
-        val tasks = taskRepository.findByMenteeIdAndDate(userId, date)
+        val tasks = taskRepository.findCurrentTasks(userId, date)
 
         return Subject.entries
             .map { learningStatusMapper.map(it, tasks) }
+    }
+
+    @Transactional(readOnly = true)
+    fun getLearningStatusBySubject(userId: Long, subject: Subject, date: LocalDate): LearningHistoryResponse {
+        val todayTasks = taskRepository.findCurrentTasksDueDateExists(userId, date)
+            .filter { it.subject == subject }
+            .sortedWith(compareBy<Task> { it.completed }.thenByDescending { it.id })
+
+        val historyTasks = taskRepository.findPreviousTasks(userId, subject, date)
+            .sortedWith(compareBy<Task> { it.completed }.thenByDescending { it.id })
+
+        return learningHistoryMapper.map(todayTasks, historyTasks)
     }
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
@@ -1,5 +1,6 @@
 package goodspace.bllsoneshot.repository.task
 
+import goodspace.bllsoneshot.entity.assignment.Subject
 import goodspace.bllsoneshot.entity.assignment.Task
 import java.time.LocalDate
 import org.springframework.data.jpa.repository.JpaRepository
@@ -15,7 +16,26 @@ interface TaskRepository : JpaRepository<Task, Long> {
         AND (t.dueDate IS NULL OR :date <= t.dueDate)
         """
     )
-    fun findByMenteeIdAndDate(userId: Long, date: LocalDate): List<Task>
+    fun findCurrentTasks(userId: Long, date: LocalDate): List<Task>
+
+    @Query(
+        """
+        SELECT t FROM Task t
+        WHERE t.mentee.id = :userId
+        AND (t.startDate IS NULL OR :date >= t.startDate)
+        AND t.dueDate IS NOT NULL AND :date <= t.dueDate
+        """
+    )
+    fun findCurrentTasksDueDateExists(userId: Long, date: LocalDate): List<Task>
+
+    @Query(
+        """
+        SELECT t FROM Task t
+        WHERE t.mentee.id = :userId AND t.subject = :subject
+        AND (t.dueDate IS NULL OR t.dueDate < :date)
+        """
+    )
+    fun findPreviousTasks(userId: Long, subject: Subject, date: LocalDate): List<Task>
 
     @Query(
         """

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -33,7 +33,7 @@ class TaskService(
         userId: Long,
         date: LocalDate
     ): List<TaskResponse> {
-        val tasks = taskRepository.findByMenteeIdAndDate(userId, date)
+        val tasks = taskRepository.findCurrentTasks(userId, date)
 
         return taskMapper.map(tasks)
     }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
과목별 학습 현황(히스토리) 조회 API를 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #63 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
