### PR TITLE
feat: 할 일 상세보기 API 응답에, 피드백 존재 유무 추가 응답

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskDetailResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/TaskDetailResponse.kt
@@ -14,6 +14,7 @@ data class TaskDetailResponse(
     val goalMinutes: Int,
     val actualMinutes: Int?,
 
+    val hasFeedback: Boolean,
     val generalComment: String?,
     val mentorName: String,
 

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskDetailMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskDetailMapper.kt
@@ -18,6 +18,7 @@ class TaskDetailMapper(
             subject = task.subject,
             goalMinutes = task.goalMinutes,
             actualMinutes = task.actualMinutes,
+            hasFeedback = task.hasFeedback(),
             generalComment = task.generalComment?.content,
             mentorName = task.mentee.mentor?.name ?: "",
             worksheets = task.worksheets.map { worksheetMapper.map(it) },


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
기존엔 `generalComment`가 `null`인지 여부로 피드백 존재 유무를 전달하고 있었지만, 더 명확하게 응답하도록 별도의 필드를 추가했습니다.
