### PR TITLE
fix: 배포 자동 CI/CD 미동작 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_0900_ai_ci
     volumes:
-      - ./data/mysql:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes"]
     volumes:
-      - ./data/redis:/data
+      - redis_data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -69,3 +69,7 @@ services:
 networks:
   bllsoneshot-net:
     driver: bridge
+
+volumes:
+  mysql_data:
+  redis_data:


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->

- 배포 서버의 자동 CI/CD가 동작하지 않는 문제를 해결했습니다.
- 배포 서버 DB의 데이터가 저장되던 방식을 bind mount 방식에서 named volume 방식으로 수정했습니다.
- bind mount 방식: 서버 컴퓨터의 폴더를 도커 컨테이너 안에 붙혀서 그 안에 DB 데이터 저장
- named volume 방식: Docker가 알아서 관리해주는 외장하드 같은 저장소인 named volume에 DB 데이터 저장

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #92

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
