### PR TITLE
feat(resources): 멘토 대시보드의 자료 등록 기능 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -5,6 +5,7 @@ import goodspace.bllsoneshot.entity.user.User
 import goodspace.bllsoneshot.entity.user.UserRole
 import goodspace.bllsoneshot.global.exception.ExceptionMessage.NEGATIVE_ACTUAL_MINUTES
 import jakarta.persistence.*
+import org.hibernate.annotations.BatchSize
 import java.time.LocalDate
 
 @Entity
@@ -27,12 +28,16 @@ class Task(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val createdBy: UserRole
+    val createdBy: UserRole,
+
+    @Column(nullable = false)
+    val isResource: Boolean = false
 ) : BaseEntity() {
     // Task 저장시 연관 엔티티도 함게 저장, 삭제되도록 cascade 및 orphanRemoval 설정
     @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.REMOVE], orphanRemoval = true)
     val worksheets: MutableList<Worksheet> = mutableListOf()
 
+    @BatchSize(size = 50)
     @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.REMOVE], orphanRemoval = true)
     val columnLinks: MutableList<ColumnLink> = mutableListOf()
 

--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -20,5 +20,7 @@ enum class ExceptionMessage(
     NEGATIVE_ACTUAL_MINUTES("학습 시간은 음수일 수 없습니다."),
     DATES_REQUIRED("날짜는 최소 1개 이상 선택해야 합니다."),
     DUPLICATE_DATES_NOT_ALLOWED("중복된 날짜는 선택할 수 없습니다."),
-    PAST_DATES_NOT_ALLOWED("과거 날짜는 선택할 수 없습니다.")
+    PAST_DATES_NOT_ALLOWED("과거 날짜는 선택할 수 없습니다."),
+    RESOURCE_SUBJECT_INVALID("자료 과목은 KOREAN, ENGLISH, MATH 중 하나여야 합니다."),
+    RESOURCE_ACCESS_DENIED("해당 멘티의 자료에 대한 권한이 없습니다.")
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
@@ -17,6 +17,7 @@ interface TaskRepository : JpaRepository<Task, Long> {
         SELECT t FROM Task t
         WHERE t.mentee.id = :userId
         AND t.date = :date
+        AND t.isResource = false
         """
     )
     fun findCurrentTasks(userId: Long, date: LocalDate): List<Task>
@@ -26,6 +27,7 @@ interface TaskRepository : JpaRepository<Task, Long> {
         SELECT t FROM Task t
         WHERE t.mentee.id = :userId AND t.subject = :subject
         AND t.date < :date
+        AND t.isResource = false
         """
     )
     fun findPreviousTasks(userId: Long, subject: Subject, date: LocalDate): List<Task>
@@ -38,6 +40,7 @@ interface TaskRepository : JpaRepository<Task, Long> {
         LEFT JOIN FETCH t.generalComment
         LEFT JOIN FETCH t.proofShots
         WHERE t.id = :taskId
+        AND t.isResource = false
         """
     )
     fun findByIdWithMenteeAndGeneralCommentAndProofShots(taskId: Long): Task?
@@ -62,6 +65,7 @@ interface TaskRepository : JpaRepository<Task, Long> {
         JOIN t.proofShots ps
         WHERE m.mentor.id = :mentorId
         AND t.date = :date
+        AND t.isResource = false
         AND NOT EXISTS (
             SELECT c 
             FROM Comment c
@@ -90,6 +94,7 @@ interface TaskRepository : JpaRepository<Task, Long> {
         LEFT JOIN t.proofShots ps
         WHERE m.mentor.id = :mentorId
         AND t.date = :date
+        AND t.isResource = false
         AND ps.id IS NULL
         ORDER BY m.name
         """
@@ -98,4 +103,15 @@ interface TaskRepository : JpaRepository<Task, Long> {
         mentorId: Long,
         date: LocalDate
     ): List<PendingUploadMenteeResponse>
+
+    @Query(
+        """
+        SELECT DISTINCT t FROM Task t
+        LEFT JOIN FETCH t.worksheets
+        WHERE t.mentee.id = :menteeId
+        AND t.isResource = true
+        ORDER BY t.date DESC, t.id DESC
+        """
+    )
+    fun findResourcesByMenteeId(menteeId: Long): List<Task>
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/ResourceController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/ResourceController.kt
@@ -1,0 +1,75 @@
+package goodspace.bllsoneshot.task.controller
+
+import goodspace.bllsoneshot.global.security.userId
+import goodspace.bllsoneshot.task.dto.request.ResourceCreateRequest
+import goodspace.bllsoneshot.task.dto.response.ResourceResponse
+import goodspace.bllsoneshot.task.dto.response.ResourcesResponse
+import goodspace.bllsoneshot.task.service.ResourceService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import java.security.Principal
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@PreAuthorize("hasRole('MENTOR')")
+@RestController
+@RequestMapping("/resources")
+@Tag(name = "자료 관리 API")
+class ResourceController(
+    private val resourceService: ResourceService
+) {
+
+    @GetMapping
+    @Operation(
+        summary = "자료 목록 조회",
+        description = """
+            특정 멘티의 자료 목록을 조회합니다.
+
+            [요청]
+            menteeId: 멘티 ID
+
+            [응답]
+            resourceId: 자료 ID
+            subject: 과목(KOREAN, ENGLISH, MATH)
+            registeredDate: 등록일
+        """
+    )
+    fun getResources(
+        principal: Principal,
+        @RequestParam menteeId: Long
+    ): ResponseEntity<ResourcesResponse> {
+        val mentorId = principal.userId
+        val response = resourceService.getResources(mentorId, menteeId)
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping
+    @Operation(
+        summary = "자료 등록",
+        description = """
+            특정 멘티의 자료를 등록합니다.
+
+            [요청]
+            menteeId: 멘티 ID
+            subject: 과목(KOREAN, ENGLISH, MATH)
+            resourceName: 자료 이름
+            fileId: PDF 파일 ID(선택)
+            columnLink: 칼럼 링크(선택)
+        """
+    )
+    fun createResource(
+        principal: Principal,
+        @Valid @RequestBody request: ResourceCreateRequest
+    ): ResponseEntity<ResourceResponse> {
+        val mentorId = principal.userId
+        val response = resourceService.createResource(mentorId, request)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/ResourceCreateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/request/ResourceCreateRequest.kt
@@ -1,0 +1,13 @@
+package goodspace.bllsoneshot.task.dto.request
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+import jakarta.validation.constraints.NotBlank
+
+data class ResourceCreateRequest(
+    val menteeId: Long,
+    val subject: Subject,
+    @field:NotBlank(message = "자료 이름이 비어 있습니다.")
+    val resourceName: String,
+    val fileId: Long? = null,
+    val columnLink: String? = null
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/ResourceResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/ResourceResponse.kt
@@ -1,0 +1,15 @@
+package goodspace.bllsoneshot.task.dto.response
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.task.dto.response.feedback.ColumnLinkResponse
+import goodspace.bllsoneshot.task.dto.response.feedback.WorksheetResponse
+import java.time.LocalDate
+
+data class ResourceResponse(
+    val resourceId: Long,
+    val subject: Subject,
+    val resourceName: String,
+    val registeredDate: LocalDate,
+    val worksheets: List<WorksheetResponse>,
+    val columnLinks: List<ColumnLinkResponse>
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/ResourcesResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/ResourcesResponse.kt
@@ -1,0 +1,5 @@
+package goodspace.bllsoneshot.task.dto.response
+
+data class ResourcesResponse(
+    val resources: List<ResourceResponse>
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/ResourceMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/ResourceMapper.kt
@@ -1,0 +1,26 @@
+package goodspace.bllsoneshot.task.mapper
+
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.task.dto.response.ResourceResponse
+import org.springframework.stereotype.Component
+
+@Component
+class ResourceMapper(
+    private val worksheetMapper: WorksheetMapper,
+    private val columnLinkMapper: ColumnLinkMapper
+) {
+
+    fun map(task: Task): ResourceResponse {
+        return ResourceResponse(
+            resourceId = task.id!!,
+            subject = task.subject,
+            resourceName = task.name,
+            registeredDate = task.date ?: java.time.LocalDate.now(),
+            worksheets = task.worksheets.map { worksheetMapper.map(it) },
+            columnLinks = task.columnLinks.map { columnLinkMapper.map(it) }
+        )
+    }
+
+    fun map(tasks: List<Task>): List<ResourceResponse> =
+        tasks.map { map(it) }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/ResourceService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/ResourceService.kt
@@ -1,0 +1,83 @@
+package goodspace.bllsoneshot.task.service
+
+import goodspace.bllsoneshot.entity.assignment.ColumnLink
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.entity.assignment.Worksheet
+import goodspace.bllsoneshot.entity.user.User
+import goodspace.bllsoneshot.entity.user.UserRole
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.FILE_NOT_FOUND
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.RESOURCE_ACCESS_DENIED
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.RESOURCE_SUBJECT_INVALID
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.USER_NOT_FOUND
+import goodspace.bllsoneshot.repository.file.FileRepository
+import goodspace.bllsoneshot.repository.task.TaskRepository
+import goodspace.bllsoneshot.repository.user.UserRepository
+import goodspace.bllsoneshot.task.dto.request.ResourceCreateRequest
+import goodspace.bllsoneshot.task.dto.response.ResourceResponse
+import goodspace.bllsoneshot.task.dto.response.ResourcesResponse
+import goodspace.bllsoneshot.task.mapper.ResourceMapper
+import java.time.LocalDate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ResourceService(
+    private val taskRepository: TaskRepository,
+    private val fileRepository: FileRepository,
+    private val userRepository: UserRepository,
+    private val resourceMapper: ResourceMapper
+) {
+
+    @Transactional(readOnly = true)
+    fun getResources(mentorId: Long, menteeId: Long): ResourcesResponse {
+        val mentee = userRepository.findById(menteeId)
+            .orElseThrow { IllegalArgumentException(USER_NOT_FOUND.message) }
+
+        validateMentorAccess(mentorId, mentee)
+
+        val resources = taskRepository.findResourcesByMenteeId(menteeId)
+
+        return ResourcesResponse(resourceMapper.map(resources))
+    }
+
+    @Transactional
+    fun createResource(mentorId: Long, request: ResourceCreateRequest): ResourceResponse {
+        val mentee = userRepository.findById(request.menteeId)
+            .orElseThrow { IllegalArgumentException(USER_NOT_FOUND.message) }
+
+        validateMentorAccess(mentorId, mentee)
+        validateResourceRequest(request)
+
+        val resource = Task(
+            mentee = mentee,
+            subject = request.subject,
+            date = LocalDate.now(),
+            name = request.resourceName,
+            goalMinutes = 0,
+            createdBy = UserRole.ROLE_MENTOR,
+            isResource = true
+        )
+
+        request.fileId?.let { fileId ->
+            val file = fileRepository.findById(fileId)
+                .orElseThrow { IllegalArgumentException(FILE_NOT_FOUND.message) }
+            resource.worksheets.add(Worksheet(resource, file))
+        }
+        request.columnLink
+            ?.takeIf { it.isNotBlank() }
+            ?.let { link -> resource.columnLinks.add(ColumnLink(resource, link)) }
+
+        val saved = taskRepository.save(resource)
+
+        return resourceMapper.map(saved)
+    }
+
+    private fun validateMentorAccess(mentorId: Long, mentee: User) {
+        check(mentee.mentor?.id == mentorId) { RESOURCE_ACCESS_DENIED.message }
+    }
+
+    private fun validateResourceRequest(request: ResourceCreateRequest) {
+        require(request.subject != Subject.RESOURCE) { RESOURCE_SUBJECT_INVALID.message }
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -251,8 +251,14 @@ class TaskService(
     }
 
     private fun findTaskBy(taskId: Long): Task {
-        return taskRepository.findById(taskId)
+        val task = taskRepository.findById(taskId)
             .orElseThrow { IllegalArgumentException(TASK_NOT_FOUND.message) }
+
+        if (task.isResource) {
+            throw IllegalArgumentException(TASK_NOT_FOUND.message)
+        }
+
+        return task
     }
 
     private fun validateTaskOwnership(


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
- 멘토 대시보드의 '자료 등록' 기능을 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #52 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
