### PR TITLE
refactor(deploy): Docker 컨테이너의 포트가 호스트에 매핑되도록 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     command: >
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_0900_ai_ci
+    ports:
+        - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
- Docker 컨테이너의 포트가 호스트에 매핑되도록 설정했습니다. (3306)

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #94 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
