### PR TITLE
chore(file): 서버에 업로드 가능한 파일의 용량 제한 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,10 @@ jobs:
             "CLOUD_AWS_BUCKET=${{ secrets.CLOUD_AWS_BUCKET }}" \
             "CLOUD_AWS_CDN_URL=${{ secrets.CLOUD_AWS_CDN_URL }}" \
             "" \
+            "SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE=${{ secrets.SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE }}" \
+            "SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE=${{ secrets.SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE }}" \
+            "APP_FILE_MAX_BYTES=${{ secrets.APP_FILE_MAX_BYTES }}" \
+            "" \
             "CF_TUNNEL_TOKEN=${{ secrets.CF_TUNNEL_TOKEN }}" \
             "APP_IMAGE=$IMAGE" \
             > .env

--- a/src/main/kotlin/goodspace/bllsoneshot/file/service/FileService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/file/service/FileService.kt
@@ -23,11 +23,11 @@ class FileService(
     private val s3Client: S3Client,
     private val fileRepository: FileRepository,
     private val s3Presigner: S3Presigner,
-    @Value("\${aws.s3.bucket}") private val bucket: String
+    @Value("\${aws.s3.bucket}") private val bucket: String,
+    @Value("\${app.file.max-bytes}") private val maxBytes: Long
 ) {
     companion object {
         private val ALLOWED_TYPES = setOf("image/png", "image/jpeg", "application/pdf")
-        private const val MAX_BYTES = 10L * 1024 * 1024 // 10MB
         private val logger = KotlinLogging.logger {}
     }
 
@@ -82,7 +82,7 @@ class FileService(
     private fun validateFile(file: MultipartFile) {
         require(!file.isEmpty) { "파일이 비어 있습니다." }
         require(file.contentType in ALLOWED_TYPES) { "지원하지 않는 파일 타입입니다." }
-        require(file.size <= MAX_BYTES) { "파일 용량이 너무 큽니다." }
+        require(file.size <= maxBytes) { "파일 용량이 너무 큽니다." }
     }
 
     private fun uploadToS3(file: MultipartFile, folder: String): UploadedFile {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,10 +15,17 @@ app:
       path: /api/auth
       secure: ${REFRESH_TOKEN_COOKIE_SECURE:false}
       same-site: lax
+  file:
+    max-bytes: ${APP_FILE_MAX_BYTES}
 
 spring:
   application:
     name: bllsoneshot
+
+  servlet:
+    multipart:
+      max-file-size: ${SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE}
+      max-request-size: ${SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE}
 
   datasource:
     url: ${SPRING_DATASOURCE_URL}


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
- 서버에 파일을 업로드 할 때 용량 제한을 설정합니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #101 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
