### PR TITLE
feat: 멘티의 간략한 정보 조회 기능 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mentor/controller/MentorController.kt
@@ -1,0 +1,47 @@
+package goodspace.bllsoneshot.mentor.controller
+
+import goodspace.bllsoneshot.global.security.userId
+import goodspace.bllsoneshot.mentor.dto.response.MenteeInfoResponse
+import goodspace.bllsoneshot.mentor.service.MentorService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.security.Principal
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@PreAuthorize("hasRole('MENTOR')")
+@RestController
+@RequestMapping("/mentors")
+@Tag(name = "멘토 API")
+class MentorController(
+    private val mentorService: MentorService
+) {
+    @GetMapping("/mentees/{menteeId}")
+    @Operation(
+        summary = "멘티의 간단한 정보 조회",
+        description = """
+            멘토가 담당하는 특정 멘티의 기본 정보를 조회합니다.
+            
+            [요청]
+            menteeId: 조회할 멘티의 ID (path variable)
+            
+            [응답]
+            menteeId: 멘티 ID
+            menteeName: 멘티 이름
+            grade: 멘티 학년
+            subjects: 관리 과목 목록 (복수 가능) — KOREAN, ENGLISH, MATH
+        """
+    )
+    fun getMenteeInfo(
+        principal: Principal,
+        @PathVariable menteeId: Long
+    ): ResponseEntity<MenteeInfoResponse> {
+        val mentorId = principal.userId
+        val response = mentorService.getMenteeInfo(mentorId, menteeId)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/mentor/dto/response/MenteeInfoResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mentor/dto/response/MenteeInfoResponse.kt
@@ -1,0 +1,10 @@
+package goodspace.bllsoneshot.mentor.dto.response
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+
+data class MenteeInfoResponse(
+    val menteeId: Long,
+    val menteeName: String,
+    val grade: String?,
+    val subjects: List<Subject>
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/mentor/service/MentorService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mentor/service/MentorService.kt
@@ -1,0 +1,30 @@
+package goodspace.bllsoneshot.mentor.service
+
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.MENTEE_ACCESS_DENIED
+import goodspace.bllsoneshot.global.exception.ExceptionMessage.USER_NOT_FOUND
+import goodspace.bllsoneshot.mentor.dto.response.MenteeInfoResponse
+import goodspace.bllsoneshot.repository.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MentorService(
+    private val userRepository: UserRepository
+) {
+    @Transactional(readOnly = true)
+    fun getMenteeInfo(mentorId: Long, menteeId: Long): MenteeInfoResponse {
+        val mentee = userRepository.findMenteeWithSubjectsById(menteeId)
+            ?: throw IllegalArgumentException(USER_NOT_FOUND.message)
+
+        if (mentee.mentor?.id != mentorId) {
+            throw IllegalArgumentException(MENTEE_ACCESS_DENIED.message)
+        }
+
+        return MenteeInfoResponse(
+            menteeId = mentee.id!!,
+            menteeName = mentee.name,
+            grade = mentee.grade,
+            subjects = mentee.subjects.map { it.subject }
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/bllsoneshot/repository/user/UserRepository.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/repository/user/UserRepository.kt
@@ -16,4 +16,13 @@ interface UserRepository : JpaRepository<User, Long> {
         """
     )
     fun findMenteesWithSubjectsByMentorId(mentorId: Long): List<User>
+
+    @Query(
+        """
+        SELECT u FROM User u
+        LEFT JOIN FETCH u.subjects
+        WHERE u.id = :menteeId
+        """
+    )
+    fun findMenteeWithSubjectsById(menteeId: Long): User?
 }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
- 멘토 할 일 등록 페이지에서 필요로 하는 멘티의 간략한 정보를 조회하는 기능을 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #111 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
