### PR TITLE
feat: 멘토 기준 할일 수정, 삭제 기능 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/global/exception/ExceptionMessage.kt
@@ -38,5 +38,6 @@ enum class ExceptionMessage(
     GENERAL_COMMENT_TOO_LONG("멘토의 총평은 200자를 초과할 수 없습니다."),
     GENERAL_COMMENT_REQUIRED("최종 저장 시 멘토의 총평은 필수입니다."),
     PROOF_SHOT_NOT_FOUND("해당 인증 사진을 찾을 수 없습니다."),
-    FEEDBACK_CONTENT_BLANK("피드백 내용이 비어 있습니다.")
+    FEEDBACK_CONTENT_BLANK("피드백 내용이 비어 있습니다."),
+    TASK_NOT_CREATED_BY_MENTOR("멘토가 등록한 할 일이 아닙니다.")
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/mentor/dto/request/MentorTaskUpdateRequest.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mentor/dto/request/MentorTaskUpdateRequest.kt
@@ -1,14 +1,22 @@
 package goodspace.bllsoneshot.mentor.dto.request
 
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.task.dto.request.ColumnLinkCreateRequest
+import goodspace.bllsoneshot.task.dto.request.WorksheetCreateRequest
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.PositiveOrZero
 import jakarta.validation.constraints.Size
 
 data class MentorTaskUpdateRequest(
+    val subject: Subject,
+
     @field:NotBlank(message = "할 일 이름이 비어 있습니다.")
     @field:Size(max = 50, message = "할 일 이름은 50자를 초과할 수 없습니다.")
     val taskName: String,
 
     @field:PositiveOrZero(message = "목표 시간은 0 이상이어야 합니다.")
-    val goalMinutes: Int
+    val goalMinutes: Int,
+
+    val worksheets: List<WorksheetCreateRequest> = emptyList(),
+    val columnLinks: List<ColumnLinkCreateRequest> = emptyList()
 )

--- a/src/main/kotlin/goodspace/bllsoneshot/mentor/dto/response/MentorTaskEditResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mentor/dto/response/MentorTaskEditResponse.kt
@@ -1,0 +1,16 @@
+package goodspace.bllsoneshot.mentor.dto.response
+
+import goodspace.bllsoneshot.entity.assignment.Subject
+import goodspace.bllsoneshot.task.dto.response.feedback.ColumnLinkResponse
+import goodspace.bllsoneshot.task.dto.response.feedback.WorksheetResponse
+import java.time.LocalDate
+
+data class MentorTaskEditResponse(
+    val subject: Subject,
+    val date: LocalDate?,
+    val taskName: String,
+    val goalMinutes: Int,
+    val worksheets: List<WorksheetResponse>,
+    val columnLinks: List<ColumnLinkResponse>,
+    val completed: Boolean,
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/mentor/mapper/MentorTaskMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/mentor/mapper/MentorTaskMapper.kt
@@ -3,16 +3,33 @@ package goodspace.bllsoneshot.mentor.mapper
 import goodspace.bllsoneshot.entity.assignment.ProofShot
 import goodspace.bllsoneshot.entity.assignment.Task
 import goodspace.bllsoneshot.mentor.dto.response.MentorTaskDetailResponse
+import goodspace.bllsoneshot.mentor.dto.response.MentorTaskEditResponse
 import goodspace.bllsoneshot.task.dto.response.feedback.ProofShotResponse
+import goodspace.bllsoneshot.task.mapper.ColumnLinkMapper
 import goodspace.bllsoneshot.task.mapper.FeedbackMapper
 import goodspace.bllsoneshot.task.mapper.QuestionMapper
+import goodspace.bllsoneshot.task.mapper.WorksheetMapper
 import org.springframework.stereotype.Component
 
 @Component
 class MentorTaskMapper(
     private val questionMapper: QuestionMapper,
-    private val feedbackMapper: FeedbackMapper
+    private val feedbackMapper: FeedbackMapper,
+    private val worksheetMapper: WorksheetMapper,
+    private val columnLinkMapper: ColumnLinkMapper
 ) {
+
+    fun mapToEdit(task: Task): MentorTaskEditResponse {
+        return MentorTaskEditResponse(
+            subject = task.subject,
+            date = task.date,
+            taskName = task.name,
+            goalMinutes = task.goalMinutes,
+            completed = task.completed,
+            worksheets = task.worksheets.map { worksheetMapper.map(it) },
+            columnLinks = task.columnLinks.map { columnLinkMapper.map(it) }
+        )
+    }
 
     fun mapToDetail(task: Task): MentorTaskDetailResponse {
         return MentorTaskDetailResponse(

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -305,9 +305,9 @@ class TaskService(
 
     private fun validateTaskOwnership(
         task: Task,
-        menteeId: Long
+        userId: Long
     ) {
-        check(task.mentee.id == menteeId) { TASK_ACCESS_DENIED.message }
+        check(task.mentee.id == userId) { TASK_ACCESS_DENIED.message }
     }
 
     private fun validateHasFeedback(task: Task) {


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
- 멘토가 본인 혹은 멘티가 등록한 할일을 수정하는 기능을 구현했습니다.
- 멘토가 본인이 등록한 할일을 삭제하는 기능을 구현했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #118 

## 💡 참고 사항
