### PR TITLE
feat: 할 일 목록 조회 API가 자료를 포함해 조회 가능하도록 수정

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
@@ -25,6 +25,16 @@ interface TaskRepository : JpaRepository<Task, Long> {
     @Query(
         """
         SELECT t FROM Task t
+        WHERE t.mentee.id = :userId
+        AND t.date = :date
+        AND t.isResource = true
+        """
+    )
+    fun findCurrentTasksIncludeResource(userId: Long, date: LocalDate): List<Task>
+
+    @Query(
+        """
+        SELECT t FROM Task t
         WHERE t.mentee.id = :menteeId
         AND t.date BETWEEN :startDate AND :endDate
         AND t.subject = :subject

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -50,6 +50,7 @@ class TaskController(
 
             [요청]
             date: 조회할 날짜(yyyy-MM-dd)
+            includeResources: 자료도 포함해 조회할지 여부(기본값 false)
 
             [응답]
             createdBy: 할 일을 만든 사람(ROLE_MENTOR / ROLE_MENTEE)
@@ -58,13 +59,15 @@ class TaskController(
     )
     fun getDailyTasks(
         principal: Principal,
+        @RequestParam(defaultValue = "false")
+        includeResources: Boolean,
         @RequestParam
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         date: LocalDate
     ): ResponseEntity<TasksResponse> {
         val userId = principal.userId
 
-        val response = taskService.findTasksByDate(userId, date)
+        val response = taskService.findTasksByDate(userId, includeResources, date)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -38,9 +38,14 @@ class TaskService(
     @Transactional(readOnly = true)
     fun findTasksByDate(
         userId: Long,
+        includeResources: Boolean,
         date: LocalDate
     ): TasksResponse {
-        val tasks = taskRepository.findCurrentTasks(userId, date)
+        val tasks = if (includeResources) {
+            taskRepository.findCurrentTasksIncludeResource(userId, date)
+        } else {
+            taskRepository.findCurrentTasks(userId, date)
+        }
 
         return tasksMapper.map(tasks)
     }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
파라미터를 이용해 자료 포함 여부를 선택할 수 있도록 개선했습니다.