### PR TITLE
feat: 할 일 개수 조회(월간 캘린더) API 구현

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/repository/task/TaskRepository.kt
@@ -194,4 +194,20 @@ interface TaskRepository : JpaRepository<Task, Long> {
         """
     )
     fun findResourceByIdWithMentee(resourceId: Long): Task?
+
+    @Query(
+        """
+        SELECT t FROM Task t
+        WHERE t.mentee.id = :userId
+        AND t.date BETWEEN :startDate AND :endDate
+        AND t.isResource = false
+        AND t.completed = false
+        ORDER BY t.date ASC
+        """
+    )
+    fun findTaskAmountsByDateRange(
+        userId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<Task>
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/controller/TaskController.kt
@@ -14,6 +14,7 @@ import goodspace.bllsoneshot.task.dto.response.task.TaskResponse
 import goodspace.bllsoneshot.task.dto.response.task.TasksResponse
 import goodspace.bllsoneshot.task.dto.response.feedback.TaskFeedbackResponse
 import goodspace.bllsoneshot.task.dto.response.submit.TaskSubmitResponse
+import goodspace.bllsoneshot.task.dto.response.task.TaskAmountResponse
 import goodspace.bllsoneshot.task.service.TaskService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -103,6 +104,38 @@ class TaskController(
         val userId = principal.userId
 
         val response = taskService.findTasksByDuration(userId, menteeId, subject, startDate, endDate)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/duration/amount")
+    @Operation(
+        summary = "할 일 개수 조회(월간 캘린더)",
+        description = """
+            해당 기간 내의 완료되지 않은 날짜별 할 일 개수를 조회합니다.
+            자료(RESOURCE)의 개수는 포함하지 않습니다.
+            
+            본인에 대해서만 호출할 수 있습니다.
+            
+            DTO는 날짜 순서대로 정렬됩니다.
+
+            [요청]
+            startDate: 조회 시작 날짜(yyyy-MM-dd)
+            endDate: 조회 종료 날짜(yyyy-MM-dd)
+
+            [응답]
+            date: 할 일의 날짜(yyyy-MM-dd)
+            taskAmount: 할 일의 개수
+        """
+    )
+    fun getTaskAmounts(
+        principal: Principal,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
+    ): ResponseEntity<List<TaskAmountResponse>> {
+        val userId = principal.userId
+
+        val response = taskService.findTaskAmounts(userId, startDate, endDate)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/task/TaskAmountResponse.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/dto/response/task/TaskAmountResponse.kt
@@ -1,0 +1,8 @@
+package goodspace.bllsoneshot.task.dto.response.task
+
+import java.time.LocalDate
+
+data class TaskAmountResponse(
+    val date: LocalDate,
+    val taskAmount: Int
+)

--- a/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskMapper.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/mapper/TaskMapper.kt
@@ -1,6 +1,7 @@
 package goodspace.bllsoneshot.task.mapper
 
 import goodspace.bllsoneshot.entity.assignment.Task
+import goodspace.bllsoneshot.task.dto.response.task.TaskAmountResponse
 import goodspace.bllsoneshot.task.dto.response.task.TaskByDateResponse
 import goodspace.bllsoneshot.task.dto.response.task.TaskResponse
 import org.springframework.stereotype.Component
@@ -32,6 +33,15 @@ class TaskMapper {
             .toSortedMap()
             .map { (date, taskList) ->
                 TaskByDateResponse(date = date, tasks = map(taskList))
+            }
+    }
+
+    fun mapToTaskAmounts(tasks: List<Task>): List<TaskAmountResponse> {
+        return tasks
+            .groupBy { it.date!! }
+            .toSortedMap()
+            .map { (date, taskList) ->
+                TaskAmountResponse(date = date, taskAmount = taskList.size)
             }
     }
 }

--- a/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/task/service/TaskService.kt
@@ -8,6 +8,7 @@ import goodspace.bllsoneshot.repository.file.FileRepository
 import goodspace.bllsoneshot.repository.task.TaskRepository
 import goodspace.bllsoneshot.repository.user.UserRepository
 import goodspace.bllsoneshot.task.dto.request.*
+import goodspace.bllsoneshot.task.dto.response.task.TaskAmountResponse
 import goodspace.bllsoneshot.task.dto.response.task.TaskByDateResponse
 import goodspace.bllsoneshot.task.dto.response.task.TaskDetailResponse
 import goodspace.bllsoneshot.task.dto.response.submit.TaskSubmitResponse
@@ -75,6 +76,17 @@ class TaskService(
         )
 
         return taskMapper.mapByDate(tasks)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTaskAmounts(
+        userId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<TaskAmountResponse> {
+        val tasks = taskRepository.findTaskAmountsByDateRange(userId, startDate, endDate)
+
+        return taskMapper.mapToTaskAmounts(tasks)
     }
 
     @Transactional


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
날짜별로 할 일의 개수를 조회하는 API를 구현했습니다.