### PR TITLE
fix: 멘토 기준 할일 등록시 `readFeedback`이 `ture`로 설정되는 버그 수정

### DIFF
--- a/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
+++ b/src/main/kotlin/goodspace/bllsoneshot/entity/assignment/Task.kt
@@ -72,8 +72,10 @@ class Task(
     fun hasFeedback(): Boolean =
         proofShots.any { it.hasFeedback() }
 
-    fun hasReadAllFeedbacks() =
-        proofShots.all { it.hasReadAllFeedbacks() }
+    fun hasReadAllFeedbacks(): Boolean {
+        if (!hasFeedback()) return false
+        return proofShots.all { it.hasReadAllFeedbacks() }
+    }
 
     fun markFeedbackAsRead() {
         proofShots.forEach { it.markFeedbackAsRead() }


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
- 멘토 기준 할일 등록시 `readFeedback`이 `ture`로 설정되는 버그를 수정했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #131 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
